### PR TITLE
Make Lwd exception resilient

### DIFF
--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -21,6 +21,9 @@ val prim : acquire:(unit -> 'a) -> release:('a -> unit) -> 'a prim
 val get_prim : 'a prim -> 'a t
 val invalidate : 'a prim -> unit
 
+type release_failure = exn * Printexc.raw_backtrace
+exception Release_failure of release_failure list
+
 type 'a root
 val observe : ?on_invalidate:('a -> unit) -> 'a t -> 'a root
 val set_on_invalidate : 'a root -> ('a -> unit) -> unit

--- a/lib/lwd/lwd.mli
+++ b/lib/lwd/lwd.mli
@@ -27,6 +27,7 @@ val set_on_invalidate : 'a root -> ('a -> unit) -> unit
 
 val sample : 'a root -> 'a
 val is_damaged : 'a root -> bool
+val is_released : 'a root -> bool
 val release : 'a root -> unit
 
 module Infix : sig

--- a/lib/lwd/lwd_utils.mli
+++ b/lib/lwd/lwd_utils.mli
@@ -5,3 +5,4 @@ val pack : 'a monoid -> 'a Lwd.t list -> 'a Lwd.t
 val pack_seq : 'a monoid -> 'a Lwd.t Seq.t -> 'a Lwd.t
 val pure_pack : 'a monoid -> 'a list -> 'a
 
+val trace : ('a Lwd.t -> ('a -> unit) -> 'a * 'b) -> 'b


### PR DESCRIPTION
The behavior of Lwd was not well defined when an exception was raised during graph evaluation.

This patch fixes that:
- the exception is propagated to the caller (user will receive the exception, with the proper backtrace, including internal Lwd frames)
- internal invariants of Lwd are preserved, the state is consistent: the computation can be resumed if the caller could fix the issue.

The only restriction is that "primitives" should not raise when released ("release" is a callback that is invoked when some graph primitive is no longer being observed).
In that case, the exception is ignored and a warning is emitted on standard error.

### What to do with primitives

It is difficult to give sane semantics to raising primitives. Releases happen in batches and asynchronously:
- it is difficult to make sense of the context (a primitive is released when it is not used... so the affected contexts are defined negatively: the exception will be received by contexts that do not use some feature)
- more than one exception can be raised (if multiple primitive raises): we pick one non-deterministically? we introduce a `Multiple_exception of exn list` exception?

## Alternative design: adding exceptions to Lwd monad

`Lwt` has a builtin notion of exception while `Async` does not give meaning to exceptions and encourage users to compose `Deferred` and `Result` monads to represent partial concurrent computations.

This PR choses the `Async` approach: to represent partial computations, use Result. To abort the computation, use normal OCaml exceptions. 
Before opting for this design, I implemented one version of `Lwd` that followed the `Lwt` idea, but it felt like a can of worm.