### PR TITLE
Ui: factor out "show_job" and fix handling of rebuild

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -87,7 +87,7 @@ let log_file = Filename.temp_file "citty" ".log"
 
 let () = at_exit (fun () -> Sys.remove log_file)
 
-let open_in_editor var log_lines = function
+let open_in_editor refresh log_lines = function
   | `Activate ->
       let oc = open_out_bin log_file in
       Lwd_table.iter (output_string oc) log_lines;
@@ -110,165 +110,152 @@ let open_in_editor var log_lines = function
            (fun bin ->
              Sys.command (Filename.quote bin ^ " " ^ safe_name) <> 127)
            candidates);
-
-      (* Change var to refresh view *)
-      Lwd.set var (Lwd.peek var)
+      refresh ()
   | _ -> ()
 
-let show_status dispatch var =
-  let rec aux job =
-    let status = Current_rpc.Job.status job in
-    let start_log = Current_rpc.Job.log ~start:0L job in
-    status
-    |> Lwt_result.map
-       @@ fun { Current_rpc.Job.id; description; can_cancel; can_rebuild } ->
-       let text =
-         Format.asprintf "@[<v2>Job %S:@,Description: @[%a@]@]@." id Fmt.lines
-           description
-       in
-       let buttons = Lwd.var Ui.empty in
-       [
-         ( if can_rebuild then
-           Some
-             ( W.button Notty.A.(bg red) "[Rebuild]" @@ fun () ->
-               Lwd.set buttons Ui.empty;
-               ignore (aux (Current_rpc.Job.rebuild job)) )
-         else None );
-         ( if can_cancel then
-           Some
-             ( W.button Notty.A.(bg blue) "[Cancel]" @@ fun () ->
-               Lwd.set buttons Ui.empty;
-               Lwt.async (fun () ->
-                   Current_rpc.Job.cancel job >>= fun _ ->
-                   ignore (aux job);
-                   Lwt.return_unit) )
-         else None );
-       ]
-       |> filter_map (fun x -> x)
-       |> interleave (Ui.atom (Notty.I.void 1 0))
-       |> Lwd_utils.pure_pack Ui.pack_x
-       |> Lwd.set buttons;
-       let log_lines = Lwd_table.make () in
-       let show_log table job =
-         let add str = if str <> "" then Lwd_table.append' table str in
-         let rec aux = function
-           | Error _ as e ->
-               add "ERROR";
-               Lwt.return e
-           | Ok ("", _) -> Lwt.return_ok ()
-           | Ok (data, next) ->
-               add data;
-               Current_rpc.Job.log ~start:next job >>= aux
-         in
-         start_log >>= aux
-       in
-       Lwt.async (fun () ->
-           show_log log_lines job >|= fun _ ->
-           Lwt.wakeup dispatch (open_in_editor var log_lines));
-       let description =
-         Lwd.pure (text |> NW.string |> Ui.resize ~w:0 ~sw:1)
-       in
-       let buttons =
-         Lwd.map2
-           (fun x y -> Ui.resize ~w:0 ~sw:1 (Ui.join_x x y))
-           (Lwd.get buttons)
-           (Lwd.pure (Ui.resize Ui.empty ~h:1 ~sw:1 ~bg:Notty.A.(bg (gray 1))))
-       in
-       let text_view =
-         (* Setup scrolling *)
-         let scroll_state = Lwd.var NW.default_scroll_state in
-         let set_scroll reason st =
-           let scroll_on_output =
-             reason = `Content
-             &&
-             let st' = Lwd.peek scroll_state in
-             st'.NW.position = st'.NW.bound
-             && st.NW.position = st'.NW.position
-             && st.NW.position < st.NW.bound
-           in
-           if scroll_on_output then
-             Lwd.set scroll_state { st with position = st.NW.bound }
-           else Lwd.set scroll_state st
-         in
-         let text_body =
-           W.dynamic_width ~w:0 ~sw:1 ~h:0 ~sh:1 (fun width ->
-               Lwd.bind width (W.word_wrap_string_table log_lines)
-               |> NW.vscroll_area ~state:(Lwd.get scroll_state)
-                    ~change:set_scroll
-               |> (* Scroll when dragging *)
-                  Lwd.map
-                    (Ui.mouse_area (fun ~x:_ ~y:y0 ->
-                       function
-                       | `Left ->
-                           let st = Lwd.peek scroll_state in
-                           `Grab
-                             ( (fun ~x:_ ~y:y1 ->
-                                 let position = st.position + y0 - y1 in
-                                 let position = clampi 0 st.bound position in
-                                 set_scroll `Change { st with position }),
-                               fun ~x:_ ~y:_ -> () )
-                       | _ -> `Unhandled)))
-         in
-         let scroll_bar =
-           Lwd.get scroll_state
-           |> Lwd.map (fun x ->
-                  x
-                  |> W.vertical_scrollbar ~set_scroll:(set_scroll `Change)
-                  |> Ui.resize ~w:1 ~sw:0 ~h:0 ~sh:1)
-         in
-         Lwd_utils.pack Ui.pack_x [ text_body; scroll_bar ]
-       in
-       Lwd.set var
-         (Lwd_utils.pack Ui.pack_y [ description; buttons; text_view ])
+let rec show_job pane job =
+  let dispatch, dispatch_var = Lwt.wait () in
+  let open_editor_asap = ref false in
+  let footer, set_footer =
+    let display msg = Lwd.map (fun img -> NW.string (img ^ msg)) spinner in
+    let var = Lwd.var (display " Receiving log") in
+    let footer_content = function
+      | `Opening -> display " Opening editor as soon as possible"
+      | `Done -> W.empty
+      | `Refresh -> Lwd.peek var
+    in
+    (Lwd.join (Lwd.get var), fun status -> Lwd.set var (footer_content status))
   in
-  aux
-
-let show_status dispatch_var job =
-  let result = Lwd.var W.empty in
-  show_status dispatch_var result job
-  |> Lwt_result.map (fun () -> Lwd.get result |> Lwd.join)
+  Lwt.ignore_result (Lwt.map (fun _ -> set_footer `Done) dispatch);
+  let dispatch_fun action =
+    match Lwt.state dispatch with
+    | Return fn -> fn action
+    | Fail _ -> ()
+    | Sleep ->
+        if (not !open_editor_asap) && action = `Activate then (
+          open_editor_asap := true;
+          set_footer `Opening;
+          Lwt.ignore_result (Lwt.map (fun fn -> fn `Activate) dispatch) )
+  in
+  Pane.set pane (Some dispatch_fun)
+    (Lwd.map' footer
+       (Ui.resize ~sh:1 ~fill:(Gravity.make ~h:`Negative ~v:`Positive)));
+  let status = Current_rpc.Job.status job in
+  let start_log = Current_rpc.Job.log ~start:0L job in
+  status
+  |> Lwt_result.map
+     @@ fun { Current_rpc.Job.id; description; can_cancel; can_rebuild } ->
+     let text =
+       Format.asprintf "@[<v2>Job %S:@,Description: @[%a@]@]@." id Fmt.lines
+         description
+     in
+     let buttons = Lwd.var Ui.empty in
+     [
+       ( if can_rebuild then
+         Some
+           ( W.button Notty.A.(bg red) "[Rebuild]" @@ fun () ->
+             Lwd.set buttons Ui.empty;
+             ignore (show_job pane (Current_rpc.Job.rebuild job)) )
+       else None );
+       ( if can_cancel then
+         Some
+           ( W.button Notty.A.(bg blue) "[Cancel]" @@ fun () ->
+             Lwd.set buttons Ui.empty;
+             Lwt.async (fun () ->
+                 Current_rpc.Job.cancel job >>= fun _ ->
+                 ignore (show_job pane job);
+                 Lwt.return_unit) )
+       else None );
+     ]
+     |> filter_map (fun x -> x)
+     |> interleave (Ui.atom (Notty.I.void 1 0))
+     |> Lwd_utils.pure_pack Ui.pack_x
+     |> Lwd.set buttons;
+     let log_lines = Lwd_table.make () in
+     Lwt.async (fun () ->
+         let show_log table job =
+           let add str = if str <> "" then Lwd_table.append' table str in
+           let rec aux = function
+             | Error _ as e ->
+                 add "ERROR";
+                 Lwt.return e
+             | Ok ("", _) -> Lwt.return_ok ()
+             | Ok (data, next) ->
+                 add data;
+                 Current_rpc.Job.log ~start:next job >>= aux
+           in
+           start_log >>= aux
+         in
+         show_log log_lines job >|= fun _ ->
+         let refresh () = set_footer `Refresh in
+         Lwt.wakeup dispatch_var (open_in_editor refresh log_lines));
+     let description = Lwd.pure (text |> NW.string |> Ui.resize ~w:0 ~sw:1) in
+     let buttons =
+       Lwd.map2
+         (fun x y -> Ui.resize ~w:0 ~sw:1 (Ui.join_x x y))
+         (Lwd.get buttons)
+         (Lwd.pure (Ui.resize Ui.empty ~h:1 ~sw:1 ~bg:Notty.A.(bg (gray 1))))
+     in
+     let text_view =
+       (* Setup scrolling *)
+       let scroll_state = Lwd.var NW.default_scroll_state in
+       let set_scroll reason st =
+         let scroll_on_output =
+           reason = `Content
+           &&
+           let st' = Lwd.peek scroll_state in
+           st'.NW.position = st'.NW.bound
+           && st.NW.position = st'.NW.position
+           && st.NW.position < st.NW.bound
+         in
+         if scroll_on_output then
+           Lwd.set scroll_state { st with position = st.NW.bound }
+         else Lwd.set scroll_state st
+       in
+       let text_body =
+         W.dynamic_width ~w:0 ~sw:1 ~h:0 ~sh:1 (fun width ->
+             Lwd.bind width (W.word_wrap_string_table log_lines)
+             |> NW.vscroll_area ~state:(Lwd.get scroll_state)
+                  ~change:set_scroll
+             |> (* Scroll when dragging *)
+                Lwd.map
+                  (Ui.mouse_area (fun ~x:_ ~y:y0 ->
+                     function
+                     | `Left ->
+                         let st = Lwd.peek scroll_state in
+                         `Grab
+                           ( (fun ~x:_ ~y:y1 ->
+                               let position = st.position + y0 - y1 in
+                               let position = clampi 0 st.bound position in
+                               set_scroll `Change { st with position }),
+                             fun ~x:_ ~y:_ -> () )
+                     | _ -> `Unhandled)))
+       in
+       let scroll_bar =
+         Lwd.get scroll_state
+         |> Lwd.map (fun x ->
+                x
+                |> W.vertical_scrollbar ~set_scroll:(set_scroll `Change)
+                |> Ui.resize ~w:1 ~sw:0 ~h:0 ~sh:1)
+       in
+       Lwd_utils.pack Ui.pack_x [ text_body; scroll_bar ]
+     in
+     Lwd_utils.pack Ui.pack_y [ description; buttons; text_view; footer ]
+     |> Pane.set pane (Some dispatch_fun)
 
 let show_jobs commit pane =
   Client.Commit.jobs commit >|= function
   | Ok items ->
       let select Client.{ variant; _ } =
         let pane = Pane.open_subview pane in
-        let dispatch, dispatch_var = Lwt.wait () in
-        let open_editor_asap = ref false in
-        let footer_spinner =
-          Lwd.var (Lwd.map (NW.printf "%s Receiving log") spinner)
-        in
         Lwt.ignore_result
-          (Lwt.map (fun _ -> Lwd.set footer_spinner W.empty) dispatch);
-        let dispatch_fun action =
-          match Lwt.state dispatch with
-          | Return fn -> fn action
-          | Fail _ -> ()
-          | Sleep ->
-              if (not !open_editor_asap) && action = `Activate then (
-                open_editor_asap := true;
-                let display_spinner frame =
-                  NW.string (frame ^ " Opening editor as soon as possible")
-                in
-                Lwd.set footer_spinner (Lwd.map display_spinner spinner);
-                Lwt.ignore_result (Lwt.map (fun fn -> fn `Activate) dispatch) )
-        in
-        let footer_ui = Lwd.get footer_spinner |> Lwd.join in
-        Pane.set pane (Some dispatch_fun)
-          (Lwd.map' footer_ui (fun ui ->
-               Ui.join_y (NW.string "...")
-                 (Ui.resize ~sh:1
-                    ~fill:(Gravity.make ~h:`Negative ~v:`Positive)
-                    ui)));
-        Lwt.async @@ fun () ->
-        Client.Commit.job_of_variant commit variant |> show_status dispatch_var
-        >|= function
-        | Ok ui ->
-            Pane.set pane (Some dispatch_fun)
-              (Lwd.map2' ui footer_ui Ui.join_y)
-        | Error (`Capnp e) ->
-            Pane.set pane None (Lwd.pure (NW.fmt "%a" Capnp_rpc.Error.pp e))
-        | Error `No_job -> Pane.set pane None (Lwd.pure (NW.string "No jobs"))
+          (show_job pane (Client.Commit.job_of_variant commit variant)
+           >|= function
+           | Ok () -> ()
+           | Error (`Capnp e) ->
+               Pane.set pane None (Lwd.pure (NW.fmt "%a" Capnp_rpc.Error.pp e))
+           | Error `No_job ->
+               Pane.set pane None (Lwd.pure (NW.string "No jobs")))
       and render Client.{ variant; outcome } highlight =
         Ui.hcat
           [


### PR DESCRIPTION
The rebuild button will cause a failure because of ... shared state ... :spaghetti: code.
This PR factors out the show job function to make it more functional while polishing the UI a bit.