### PR TITLE
Preview of ocamlformat 0.14.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.11.0
+version = 0.14.2
 profile = conventional
 break-infix = fit-or-vertical

--- a/src/main.ml
+++ b/src/main.ml
@@ -100,9 +100,8 @@ let open_in_editor refresh log_lines = function
             match Sys.getenv_opt "EDITOR" with
             | Some x -> [ x ]
             | None -> (
-                match Sys.getenv_opt "PAGER" with
-                | Some x -> [ x ]
-                | None -> [] ) )
+                match Sys.getenv_opt "PAGER" with Some x -> [ x ] | None -> [] )
+            )
       in
       let candidates = candidates @ [ "xdg-open"; "open" ] in
       ignore
@@ -200,11 +199,7 @@ let rec show_job pane job =
        (* Setup scrolling *)
        let scroll_state = Lwd.var NW.default_scroll_state in
        let set_scroll reason st =
-         let off_screen =
-           reason = `Content
-           &&
-           st.NW.position > st.NW.bound
-         in
+         let off_screen = reason = `Content && st.NW.position > st.NW.bound in
          let scroll_on_output =
            reason = `Content
            &&
@@ -220,21 +215,20 @@ let rec show_job pane job =
        let text_body =
          W.dynamic_width ~w:0 ~sw:1 ~h:0 ~sh:1 (fun width ->
              Lwd.bind width (W.word_wrap_string_table log_lines)
-             |> NW.vscroll_area ~state:(Lwd.get scroll_state)
-                  ~change:set_scroll
+             |> NW.vscroll_area ~state:(Lwd.get scroll_state) ~change:set_scroll
              |> (* Scroll when dragging *)
-                Lwd.map
-                  (Ui.mouse_area (fun ~x:_ ~y:y0 ->
-                     function
-                     | `Left ->
-                         let st = Lwd.peek scroll_state in
-                         `Grab
-                           ( (fun ~x:_ ~y:y1 ->
-                               let position = st.position + y0 - y1 in
-                               let position = clampi 0 st.bound position in
-                               set_scroll `Change { st with position }),
-                             fun ~x:_ ~y:_ -> () )
-                     | _ -> `Unhandled)))
+             Lwd.map
+               (Ui.mouse_area (fun ~x:_ ~y:y0 ->
+                  function
+                  | `Left ->
+                      let st = Lwd.peek scroll_state in
+                      `Grab
+                        ( (fun ~x:_ ~y:y1 ->
+                            let position = st.position + y0 - y1 in
+                            let position = clampi 0 st.bound position in
+                            set_scroll `Change { st with position }),
+                          fun ~x:_ ~y:_ -> () )
+                  | _ -> `Unhandled)))
        in
        let scroll_bar =
          Lwd.get scroll_state
@@ -363,19 +357,16 @@ let main () =
   Focus.request focus_handle;
   Lwd.set body
     ( Pane.render pane
-      |> Lwd.map2
-        (fun focus -> Ui.keyboard_area ~focus @@ function
-           | (`Arrow `Up | `ASCII 'k'), [] ->
-             dispatch `Middle `Select_prev
-           | (`Arrow `Down | `ASCII 'j'), [] ->
-             dispatch `Middle `Select_next
+    |> Lwd.map2
+         (fun focus ->
+           Ui.keyboard_area ~focus @@ function
+           | (`Arrow `Up | `ASCII 'k'), [] -> dispatch `Middle `Select_prev
+           | (`Arrow `Down | `ASCII 'j'), [] -> dispatch `Middle `Select_next
            | (`Arrow `Left | `ASCII 'h'), [] -> dispatch `Left `Activate
-           | (`Arrow `Right | `ASCII 'l'), [] ->
-             dispatch `Right `Activate
+           | (`Arrow `Right | `ASCII 'l'), [] -> dispatch `Right `Activate
            | (`Escape | `ASCII 'q'), [] -> exit 0
            | _ -> `Unhandled)
-        (Focus.status focus_handle);
-    );
+         (Focus.status focus_handle) );
   Lwt_main.run
     (show_repos (Pane.open_root pane) >>= function
      | Ok () -> Nottui_lwt.run ui

--- a/src/widgets.ml
+++ b/src/widgets.ml
@@ -55,15 +55,16 @@ let word_wrap_string_table table width =
           render_line str
       | lines ->
           (* Something was split:
-           - append remaining characters
-           - render each line
-           - concatenate them vertically *)
+             - append remaining characters
+             - render each line
+             - concatenate them vertically *)
           ("↳" ^ String.sub str !pos (len - !pos)) :: lines
           |> List.rev_map render_line
           |> Lwd_utils.pure_pack Ui.pack_y
     in
     (* Stack three images vertically *)
     let join3 a b c = Ui.join_y a (Ui.join_y b c) in
+
     (* Map reduce the table, lifting the strings to an intermediate type
        that is suitable for word wrapping.
 
@@ -123,10 +124,10 @@ let word_wrap_string_table table width =
                   | Some (ub, sb) -> (join3 ua (wrap_line line) ub, sb) ) ) )
       table
     |> (* After reducing the table, we produce the final UI, interpreting
-       unterminated prefix and suffix has line of their own. *)
-       Lwd.map (function
-         | pa, None -> wrap_line pa
-         | pa, Some (ub, sb) -> join3 (wrap_line pa) ub (wrap_line sb))
+          unterminated prefix and suffix has line of their own. *)
+    Lwd.map (function
+      | pa, None -> wrap_line pa
+      | pa, Some (ub, sb) -> join3 (wrap_line pa) ub (wrap_line sb))
 
 (* Grab the mouse and repeat an event until button is released *)
 let grab_and_repeat f =
@@ -185,9 +186,7 @@ let vertical_scrollbar ~set_scroll (st : Nottui_widgets.scroll_state) =
                     float st.position
                     +. (float dy /. float st.visible *. float st.total)
                   in
-                  let position =
-                    max 0 (min st.bound (int_of_float position))
-                  in
+                  let position = max 0 (min st.bound (int_of_float position)) in
                   set_scroll { st with position }),
                 fun ~x:_ ~y:_ -> () )
       | _ -> `Unhandled


### PR DESCRIPTION
As of the new release process we are implementing for ocamlformat here is the preview of what the codebase would look like after ocamlformat-0.14.2 has been applied.
This preview is not definitive, as we need to make sure it is fitting with other main ocaml projects as well, please do not merge this PR.

The .ocamlformat file has been updated for consistency although the package has not been submitted to opam yet. If you wish to test this version, remove this line in the .ocamlformat file, and use the master version of ocamlformat (as of ocaml-ppx/ocamlformat@6fb5a8c)

The diff you can see can be explained by the various changes that have been performed on comments and how they interact with ocaml code throughout ocamlformat releases since 0.11.0.
Feel free to give your feedback on this PR or open an issue on https://github.com/ocaml-ppx/ocamlformat/issues